### PR TITLE
클라이언트에서 S3 presigned post 요청을 제대로 보낼 수 있도록 고침

### DIFF
--- a/ThreePercentBackend/lib/three_percent_backend-stack.ts
+++ b/ThreePercentBackend/lib/three_percent_backend-stack.ts
@@ -21,6 +21,7 @@ export class ThreePercentBackendStack extends cdk.Stack {
                 BUCKET_NAME: bucket.bucketName,
             },
         });
+        bucket.grantReadWrite(handler);
 
         new LambdaRestApi(this, 'Api', {
             handler,


### PR DESCRIPTION
 - [AWS 문서][1]에서 제안하는 순서대로 `fields`를 맞추기 위해, JSON 객체(맵) 대신 `[string, string]`의 배열로 바꿔서 순서를 보존하도록 했습니다.
 - S3 버킷에 업로드할 수 있도록 권한 설정을 고쳤습니다.

[1]: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html